### PR TITLE
bug/issue#13: Apply 0 margins to nested container for mobile viewports

### DIFF
--- a/src/components/navigation/navigation.scss
+++ b/src/components/navigation/navigation.scss
@@ -1,0 +1,8 @@
+// Known Bootstrap bug https://github.com/twbs/bootstrap/pull/21722
+// Can be removed with the beta release v4.0.0-beta
+@media (max-width: 575px) {
+  .navbar > .container {
+    margin-right: 0;
+    margin-left: 0;
+  }
+}

--- a/src/components/navigation/navigation.tsx
+++ b/src/components/navigation/navigation.tsx
@@ -1,6 +1,7 @@
 import './navigation.scss';
 import * as React from 'react';
 import { Link } from 'react-router';
+import './navigation.scss';
 
 interface NavigationPropsInterface {
 }


### PR DESCRIPTION
<!--
## Submitting a Pull Request
We love PRs and appreciate any help you can offer.

Please make sure the following criteria is meet before submitting your pull request.

1. <strong>PR meets the  [Contributing guidelines](./CONTRIBUTING.md)</strong>
2. Fork the repository and create your branch from <i>master</i>.
3. Ensure the test suite passes (`yarn run test`).
4. Make sure your code lints (`yarn run lint`).
-->

## Associated Issue
#13 Known bug in Bootstrap v4-alpha for `.container` nested inside `.navbar`. See https://github.com/twbs/bootstrap/pull/21722

## Changes Made
Set a mobile `max-width` breakpoint, and apply 0 margins to `.navbar > .container`